### PR TITLE
[WIP][v2] Transfer logic of devfile support check from odo

### DIFF
--- a/devfiles/index.json
+++ b/devfiles/index.json
@@ -9,6 +9,7 @@
     ],
     "projectType": "maven",
     "language": "java",
+    "supported": true,
     "links": {
       "self": "/devfiles/maven/devfile.yaml"
     }
@@ -24,6 +25,7 @@
     ],
     "projectType": "nodejs",
     "language": "nodejs",
+    "supported": true,
     "links": {
       "self": "/devfiles/nodejs/devfile.yaml"
     }
@@ -34,6 +36,7 @@
     "description": "Open Liberty microservice in Java",
     "projectType": "docker",
     "language": "java",
+    "supported": true,
     "links": {
       "self": "/devfiles/openLiberty/devfile.yaml"
     }
@@ -48,6 +51,7 @@
     ],
     "projectType": "quarkus",
     "language": "java",
+    "supported": true,
     "links": {
       "self": "/devfiles/quarkus/devfile.yaml"
     }
@@ -64,6 +68,7 @@
     "icon": "https://www.eclipse.org/che/images/logo-eclipseche.svg",
     "projectType": "spring",
     "language": "java",
+    "supported": true,
     "links": {
       "self": "/devfiles/springBoot/devfile.yaml"
     }

--- a/tools/cmd/index/index.go
+++ b/tools/cmd/index/index.go
@@ -8,8 +8,13 @@ import (
 	"log"
 	"path/filepath"
 
-	"github.com/elsony/devfile-registry/tools/types"
-	"gopkg.in/yaml.v2"
+	"github.com/odo-devfiles/registry/tools/types"
+	"github.com/odo-devfiles/registry/tools/utils"
+)
+
+const (
+	metafileName = "meta.yaml"
+	devfileName  = "devfile.yaml"
 )
 
 // genIndex generate new index from meta.yaml files in dir.
@@ -25,20 +30,24 @@ func genIndex(dir string) ([]types.MetaIndex, error) {
 
 	for _, file := range dirs {
 		if file.IsDir() {
-			var meta types.Meta
-			metaFile, err := ioutil.ReadFile(filepath.Join(dir, file.Name(), "meta.yaml"))
-			if err != nil {
-				return nil, err
-			}
-			err = yaml.Unmarshal(metaFile, &meta)
+			// Read the meta.yaml
+			meta, err := utils.GetMeta(filepath.Join(dir, file.Name(), metafileName))
 			if err != nil {
 				return nil, err
 			}
 
-			self := fmt.Sprintf("/%s/%s/%s", filepath.Base(dir), file.Name(), "devfile.yaml")
+			// Read the devfile.yaml
+			devfile, err := utils.GetDevfile(filepath.Join(dir, file.Name(), devfileName))
+			if err != nil {
+				return nil, err
+			}
 
+			isSupported := utils.IsDevfileSupported(devfile)
+
+			self := fmt.Sprintf("/%s/%s/%s", filepath.Base(dir), file.Name(), devfileName)
 			metaIndex := types.MetaIndex{
-				Meta: meta,
+				Meta:      meta,
+				Supported: isSupported,
 				Links: types.Links{
 					Self: self,
 				},
@@ -51,7 +60,7 @@ func genIndex(dir string) ([]types.MetaIndex, error) {
 
 func main() {
 	devfiles := flag.String("devfiles-dir", "", "Directory containing devfiles.")
-	output := flag.String("index", "", "Index filaname. This is where the index in JSON format will be saved.")
+	output := flag.String("index", "", "Index filename. This is where the index in JSON format will be saved.")
 
 	flag.Parse()
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,4 @@ module github.com/odo-devfiles/registry/tools
 
 go 1.14
 
-require (
-	github.com/ghodss/yaml v1.0.0
-	gopkg.in/yaml.v2 v2.2.8
-)
+require gopkg.in/yaml.v2 v2.2.8

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,5 +1,8 @@
-module github.com/elsony/devfile-registry/tools
+module github.com/odo-devfiles/registry/tools
 
 go 1.14
 
-require gopkg.in/yaml.v2 v2.2.8
+require (
+	github.com/ghodss/yaml v1.0.0
+	gopkg.in/yaml.v2 v2.2.8
+)

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,5 +1,3 @@
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
-github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,3 +1,5 @@
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/tools/types/devfile.go
+++ b/tools/types/devfile.go
@@ -1,0 +1,39 @@
+package types
+
+// Metadata holds the meta information in the devfile
+type Metadata struct {
+	Name string `yaml:"name"`
+}
+
+// Container holds the container information of a component in the devfile
+type Container struct {
+	Name string `yaml:"name"`
+}
+
+// Component holds the component information in the devfile
+type Component struct {
+	Container *Container `yaml:"container"`
+}
+
+// Group holds the command group information in the devfile
+type Group struct {
+	Kind string `yaml:"kind"`
+}
+
+// Exec holds the command exec type information in the devfile
+type Exec struct {
+	Group *Group `yaml:"group"`
+}
+
+// Command holds the command information in the devfile
+type Command struct {
+	Exec *Exec `yaml:"exec"`
+}
+
+// Devfile is the necessary structure of devfile for checking if devfile is supported
+type Devfile struct {
+	APIVersion string      `yaml:"apiVersion"`
+	MetaData   Metadata    `yaml:"metadata"`
+	Components []Component `yaml:"components"`
+	Commands   []Command   `yaml:"commands"`
+}

--- a/tools/types/meta.go
+++ b/tools/types/meta.go
@@ -16,7 +16,8 @@ type Meta struct {
 // This is Meta extended with Links field
 type MetaIndex struct {
 	Meta
-	Links Links `yaml:"links,omitempty" json:"links,omitempty"`
+	Supported bool  `yaml:"supported" json:"supported"`
+	Links     Links `yaml:"links,omitempty" json:"links,omitempty"`
 }
 type Links struct {
 	Self string `yaml:"self,omitempty" json:"self,omitempty"`

--- a/tools/utils/utils.go
+++ b/tools/utils/utils.go
@@ -3,8 +3,8 @@ package utils
 import (
 	"io/ioutil"
 
-	"github.com/ghodss/yaml"
 	"github.com/odo-devfiles/registry/tools/types"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -14,36 +14,24 @@ const (
 // IsDevfileSupported checks if devfile v2 is supported
 func IsDevfileSupported(devfile types.Devfile) bool {
 
-	hasComponentContainer := false
-	hasComponentContainerName := false
+	hasSupportedContainer := false
 	hasRunGroupCommand := false
 
 	for _, component := range devfile.Components {
-		if hasComponentContainer && hasComponentContainerName {
+		if component.Container != nil && component.Container.Name != "" {
+			hasSupportedContainer = true
 			break
-		}
-
-		if !hasComponentContainer {
-			hasComponentContainer = component.Container != nil
-		}
-
-		if hasComponentContainer && !hasComponentContainerName {
-			hasComponentContainerName = len(component.Container.Name) > 0
 		}
 	}
 
 	for _, command := range devfile.Commands {
-
-		if !hasRunGroupCommand {
-			hasRunGroupCommand = command.Exec != nil && command.Exec.Group != nil && command.Exec.Group.Kind == runGroup
+		if command.Exec != nil && command.Exec.Group != nil && command.Exec.Group.Kind == runGroup {
+			hasRunGroupCommand = true
+			break
 		}
 	}
 
-	if hasComponentContainer && hasComponentContainerName && hasRunGroupCommand {
-		return true
-	}
-
-	return false
+	return hasSupportedContainer && hasRunGroupCommand
 }
 
 // GetDevfile reads the devfile from the path and returns the devfile struct

--- a/tools/utils/utils.go
+++ b/tools/utils/utils.go
@@ -11,11 +11,9 @@ const (
 	runGroup = "run"
 )
 
-// IsDevfileSupported checks if devfile v2 is supported
-func IsDevfileSupported(devfile types.Devfile) bool {
-
+// isContainerPresent checks if the devfile has a supported container component
+func isContainerPresent(devfile types.Devfile) bool {
 	hasSupportedContainer := false
-	hasRunGroupCommand := false
 
 	for _, component := range devfile.Components {
 		if component.Container != nil && component.Container.Name != "" {
@@ -24,12 +22,28 @@ func IsDevfileSupported(devfile types.Devfile) bool {
 		}
 	}
 
+	return hasSupportedContainer
+}
+
+// isRunGroupPresent checks if the devfile has a run group command
+func isRunGroupCommandPresent(devfile types.Devfile) bool {
+	hasRunGroupCommand := false
+
 	for _, command := range devfile.Commands {
 		if command.Exec != nil && command.Exec.Group != nil && command.Exec.Group.Kind == runGroup {
 			hasRunGroupCommand = true
 			break
 		}
 	}
+
+	return hasRunGroupCommand
+}
+
+// IsDevfileSupported checks if devfile v2 is supported
+func IsDevfileSupported(devfile types.Devfile) bool {
+
+	hasSupportedContainer := isContainerPresent(devfile)
+	hasRunGroupCommand := isRunGroupCommandPresent(devfile)
 
 	return hasSupportedContainer && hasRunGroupCommand
 }

--- a/tools/utils/utils.go
+++ b/tools/utils/utils.go
@@ -1,0 +1,77 @@
+package utils
+
+import (
+	"io/ioutil"
+
+	"github.com/ghodss/yaml"
+	"github.com/odo-devfiles/registry/tools/types"
+)
+
+const (
+	runGroup = "run"
+)
+
+// IsDevfileSupported checks if devfile v2 is supported
+func IsDevfileSupported(devfile types.Devfile) bool {
+
+	hasComponentContainer := false
+	hasComponentContainerName := false
+	hasRunGroupCommand := false
+
+	for _, component := range devfile.Components {
+		if hasComponentContainer && hasComponentContainerName {
+			break
+		}
+
+		if !hasComponentContainer {
+			hasComponentContainer = component.Container != nil
+		}
+
+		if hasComponentContainer && !hasComponentContainerName {
+			hasComponentContainerName = len(component.Container.Name) > 0
+		}
+	}
+
+	for _, command := range devfile.Commands {
+
+		if !hasRunGroupCommand {
+			hasRunGroupCommand = command.Exec != nil && command.Exec.Group != nil && command.Exec.Group.Kind == runGroup
+		}
+	}
+
+	if hasComponentContainer && hasComponentContainerName && hasRunGroupCommand {
+		return true
+	}
+
+	return false
+}
+
+// GetDevfile reads the devfile from the path and returns the devfile struct
+func GetDevfile(devfilePath string) (types.Devfile, error) {
+	var devfile types.Devfile
+	devFilePath, err := ioutil.ReadFile(devfilePath)
+	if err != nil {
+		return types.Devfile{}, err
+	}
+	err = yaml.Unmarshal(devFilePath, &devfile)
+	if err != nil {
+		return types.Devfile{}, err
+	}
+
+	return devfile, nil
+}
+
+// GetMeta reads the meta.yaml and returns the meta struct
+func GetMeta(metafilePath string) (types.Meta, error) {
+	var meta types.Meta
+	metaFilePath, err := ioutil.ReadFile(metafilePath)
+	if err != nil {
+		return types.Meta{}, err
+	}
+	err = yaml.Unmarshal(metaFilePath, &meta)
+	if err != nil {
+		return types.Meta{}, err
+	}
+
+	return meta, nil
+}


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysun.j.faisal@ibm.com>

For Issue https://github.com/openshift/odo/issues/3249
This PR moved the logic from odo to this repo to check if a devfile is supported.

This is done so that odo does not parse the devfile but rather read the index.json for information and this improves `odo catalog list components` performance with big registries