### PR TITLE
Removes two component types from the devfiles

### DIFF
--- a/devfiles/openLiberty/devfile.yaml
+++ b/devfiles/openLiberty/devfile.yaml
@@ -9,9 +9,9 @@ projects:
       location: 'https://github.com/odo-devfiles/openliberty-ex.git'
       branch: master
 components:
-  - chePlugin:
-      id: redhat/java/latest
-      memoryLimit: 1512Mi
+  - plugin:
+    id: redhat/java/latest
+    memoryLimit: 1512Mi
   - container:
       name: appsodyrun
       image: 'ajymau/java-openliberty-dev:latest'

--- a/devfiles/springBoot/devfile.yaml
+++ b/devfiles/springBoot/devfile.yaml
@@ -7,9 +7,9 @@ projects:
     git:
       location: "https://github.com/odo-devfiles/springboot-ex.git"
 components:
-  - chePlugin:
-      id: redhat/java/latest
-      memoryLimit: 1512Mi
+  - plugin:
+    id: redhat/java/latest
+    memoryLimit: 1512Mi
   - container:
       name: tools
       image: maysunfaisal/springbootbuild


### PR DESCRIPTION
According to https://github.com/devfile/kubernetes-api/blob/28e3e6acdc368b503672738697b149dd23c86770/schemas/devfile.json#L1165, `chePlugin` is now `plugin`.