### PR TITLE
Remove discoverable key

### DIFF
--- a/devfiles/java-openliberty/devfile.yaml
+++ b/devfiles/java-openliberty/devfile.yaml
@@ -17,7 +17,6 @@ components:
       endpoints:
         - name: 9080/tcp
           configuration:
-            discoverable: false
             public: true
             protocol: tcp
             scheme: http

--- a/devfiles/java-quarkus/devfile.yaml
+++ b/devfiles/java-quarkus/devfile.yaml
@@ -19,7 +19,6 @@ components:
       endpoints:
         - name: '8080/http'
           configuration:
-            discoverable: false
             public: true
             protocol: tcp
             scheme: http


### PR DESCRIPTION
Key is not supported by schema / not available upstream.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>