### PR TITLE
remove endpoint configuration

### DIFF
--- a/devfiles/java-maven/devfile.yaml
+++ b/devfiles/java-maven/devfile.yaml
@@ -10,8 +10,6 @@ components:
       mountSources: true
       endpoints:
         - name: 'http-8080'
-          configuration:
-            public: true
           targetPort: 8080
       volumeMounts:
         - name: m2

--- a/devfiles/java-openliberty/devfile.yaml
+++ b/devfiles/java-openliberty/devfile.yaml
@@ -19,11 +19,6 @@ components:
       mountSources: true
       endpoints:
         - name: 9080/tcp
-          configuration:
-            discoverable: false
-            public: true
-            protocol: tcp
-            scheme: http
           targetPort: 9080
 commands:
 # devInit currently not functional in odo devfile v2 - will re-enable when available

--- a/devfiles/java-quarkus/devfile.yaml
+++ b/devfiles/java-quarkus/devfile.yaml
@@ -18,11 +18,6 @@ components:
           path: /home/user/.m2
       endpoints:
         - name: '8080/http'
-          configuration:
-            discoverable: false
-            public: true
-            protocol: tcp
-            scheme: http
           targetPort: 8080
 commands:
   - exec:

--- a/devfiles/java-springboot/devfile.yaml
+++ b/devfiles/java-springboot/devfile.yaml
@@ -25,8 +25,6 @@ components:
       args: [ '-f', '/dev/null']
       endpoints:
         - name: '8080/tcp'
-          configuration:
-            public: true
           targetPort: 8080
       mountSources: false
       volumeMounts:

--- a/devfiles/nodejs/devfile.yaml
+++ b/devfiles/nodejs/devfile.yaml
@@ -15,10 +15,6 @@ components:
       endpoints:
         - name: http-3000
           targetPort: 3000
-          configuration:
-            protocol: tcp
-            scheme: http
-            type: terminal
 commands:
   - exec:
       id: install


### PR DESCRIPTION
Devfile spec was recently updated, and container endpoints have been redefined.
In the new spec, there is no configuration field.

This PR removes the configuration field from endpoints to make devfiles valid again. 

Once https://github.com/openshift/odo/issues/3515 is implemented we can put some of the configurations back to a proper place.

