### PR TITLE
Outerloop for nodejs devfile

### DIFF
--- a/devfiles/nodejs/build/Dockerfile
+++ b/devfiles/nodejs/build/Dockerfile
@@ -1,5 +1,5 @@
 # Install the app dependencies in a full Node docker image
-FROM registry.access.redhat.com/ubi8/nodejs-12:1-36
+FROM registry.access.redhat.com/ubi8/nodejs-12:1-45
 
 COPY . /project/
 

--- a/devfiles/nodejs/build/Dockerfile
+++ b/devfiles/nodejs/build/Dockerfile
@@ -1,0 +1,17 @@
+# Install the app dependencies in a full Node docker image
+FROM registry.access.redhat.com/ubi8/nodejs-12:1-36
+
+COPY . /project/
+
+# Support arbitrary user ids
+RUN chgrp -R 0 /project && \
+    chmod -R g=u /project
+
+# Removing node_modules
+RUN rm -rf /project/node_modules
+
+# Install user-app dependencies
+WORKDIR /project
+RUN npm install --production
+
+CMD ["npm", "start"]

--- a/devfiles/nodejs/deploy/deployment-manifest.yaml
+++ b/devfiles/nodejs/deploy/deployment-manifest.yaml
@@ -1,0 +1,60 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: COMPONENT_NAME
+  labels:
+    app.kubernetes.io/instance: COMPONENT_NAME
+    app.kubernetes.io/name: COMPONENT_NAME
+    app.kubernetes.io/part-of: COMPONENT_NAME
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: COMPONENT_NAME
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: COMPONENT_NAME
+    spec:
+      containers:
+        - name: COMPONENT_NAME
+          image: CONTAINER_IMAGE
+          ports:
+            - name: http
+              containerPort: PORT
+              protocol: TCP
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: COMPONENT_NAME
+spec:
+  ports:
+    - protocol: TCP
+      port: PORT
+      targetPort: PORT
+  selector:
+    app: COMPONENT_NAME
+  type: ClusterIP
+  sessionAffinity: None
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: COMPONENT_NAME
+  labels:
+    app.kubernetes.io/instance: COMPONENT_NAME
+    app.kubernetes.io/name: COMPONENT_NAME
+    app.kubernetes.io/part-of: COMPONENT_NAME
+  annotations:
+    openshift.io/host.generated: 'true'
+spec:
+  to:
+    kind: Service
+    name: COMPONENT_NAME
+    weight: 100
+  port:
+    targetPort: PORT
+  wildcardPolicy: None

--- a/devfiles/nodejs/deploy/deployment-manifest.yaml
+++ b/devfiles/nodejs/deploy/deployment-manifest.yaml
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/name: COMPONENT_NAME
     app.kubernetes.io/part-of: COMPONENT_NAME
   annotations:
-    openshift.io/host.generated: 'true'
+    openshift.io/host.generated: "true"
 spec:
   to:
     kind: Service

--- a/devfiles/nodejs/devfile.yaml
+++ b/devfiles/nodejs/devfile.yaml
@@ -2,8 +2,8 @@ schemaVersion: 2.0.0
 metadata:
   name: nodejs
   version: 1.0.0
-  alpha.build-dockerfile: https://github.com/neeraj-laad/registry/blob/master/devfiles/nodejs/build/Dockerfile
-  alpha.deployment-manifest: https://raw.githubusercontent.com/neeraj-laad/registry/master/devfiles/nodejs/deploy/deployment-manifest.yaml
+  alpha.build-dockerfile: "https://raw.githubusercontent.com/neeraj-laad/registry/blob/master/devfiles/nodejs/build/Dockerfile"
+  alpha.deployment-manifest: "https://raw.githubusercontent.com/neeraj-laad/registry/master/devfiles/nodejs/deploy/deployment-manifest.yaml"
 projects:
   - name: nodejs-starter
     git:

--- a/devfiles/nodejs/devfile.yaml
+++ b/devfiles/nodejs/devfile.yaml
@@ -2,8 +2,8 @@ schemaVersion: 2.0.0
 metadata:
   name: nodejs
   version: 1.0.0
-  alpha.build-dockerfile: "https://raw.githubusercontent.com/neeraj-laad/registry/master/devfiles/nodejs/build/Dockerfile"
-  alpha.deployment-manifest: "https://raw.githubusercontent.com/neeraj-laad/registry/master/devfiles/nodejs/deploy/deployment-manifest.yaml"
+  alpha.build-dockerfile: "https://raw.githubusercontent.com/odo-devfiles/registry/master/devfiles/nodejs/build/Dockerfile"
+  alpha.deployment-manifest: "https://raw.githubusercontent.com/odo-devfiles/registry/master/devfiles/nodejs/deploy/deployment-manifest.yaml"
 projects:
   - name: nodejs-starter
     git:

--- a/devfiles/nodejs/devfile.yaml
+++ b/devfiles/nodejs/devfile.yaml
@@ -11,7 +11,7 @@ projects:
 components:
   - container:
       name: runtime
-      image: registry.access.redhat.com/ubi8/nodejs-12:1-36
+      image: registry.access.redhat.com/ubi8/nodejs-12:1-45
       memoryLimit: 1024Mi
       mountSources: true
       endpoints:

--- a/devfiles/nodejs/devfile.yaml
+++ b/devfiles/nodejs/devfile.yaml
@@ -2,6 +2,8 @@ schemaVersion: 2.0.0
 metadata:
   name: nodejs
   version: 1.0.0
+  alpha.build-dockerfile: "https://raw.githubusercontent.com/odo-devfiles/registry/master/devfiles/nodejs/build/Dockerfile"
+alpha.deployment-manifest: "https://raw.githubusercontent.com/groeges/devfile-registry/master/devfiles/nodejs/deploy/deployment-manifest.yaml" 
 projects:
   - name: nodejs-starter
     git:

--- a/devfiles/nodejs/devfile.yaml
+++ b/devfiles/nodejs/devfile.yaml
@@ -2,8 +2,8 @@ schemaVersion: 2.0.0
 metadata:
   name: nodejs
   version: 1.0.0
-  alpha.build-dockerfile: "https://raw.githubusercontent.com/odo-devfiles/registry/master/devfiles/nodejs/build/Dockerfile"
-alpha.deployment-manifest: "https://raw.githubusercontent.com/groeges/devfile-registry/master/devfiles/nodejs/deploy/deployment-manifest.yaml" 
+  alpha.build-dockerfile: https://github.com/neeraj-laad/registry/blob/master/devfiles/nodejs/build/Dockerfile
+  alpha.deployment-manifest: https://raw.githubusercontent.com/neeraj-laad/registry/master/devfiles/nodejs/deploy/deployment-manifest.yaml
 projects:
   - name: nodejs-starter
     git:

--- a/devfiles/nodejs/devfile.yaml
+++ b/devfiles/nodejs/devfile.yaml
@@ -2,7 +2,7 @@ schemaVersion: 2.0.0
 metadata:
   name: nodejs
   version: 1.0.0
-  alpha.build-dockerfile: "https://raw.githubusercontent.com/neeraj-laad/registry/blob/master/devfiles/nodejs/build/Dockerfile"
+  alpha.build-dockerfile: "https://raw.githubusercontent.com/neeraj-laad/registry/master/devfiles/nodejs/build/Dockerfile"
   alpha.deployment-manifest: "https://raw.githubusercontent.com/neeraj-laad/registry/master/devfiles/nodejs/deploy/deployment-manifest.yaml"
 projects:
   - name: nodejs-starter


### PR DESCRIPTION
This PR adds:

- outerloop metadata to nodejs devfile
- dockerfile for building the application
- deployment manifest for deploying the application on OpenShift


This will be used by `odo deploy` when https://github.com/openshift/odo/pull/3478 gets merged. Could perhaps also help with testing on that PR. 

Having this merged earlier will not impact any existing capabilities of the stack, so should be safe to add.