### PR TITLE
Add in the volume components

### DIFF
--- a/devfiles/java-maven/devfile.yaml
+++ b/devfiles/java-maven/devfile.yaml
@@ -14,6 +14,8 @@ components:
       volumeMounts:
         - name: m2
           path: /home/user/.m2
+  - volume:
+      name: m2
 commands:
   - exec:
       id: mvn-package

--- a/devfiles/java-quarkus/devfile.yaml
+++ b/devfiles/java-quarkus/devfile.yaml
@@ -19,6 +19,9 @@ components:
       endpoints:
         - name: '8080/http'
           targetPort: 8080
+  - volume:
+      name: m2
+      size: 3Gi
 commands:
   - exec:
       id: init-compile

--- a/devfiles/java-springboot/devfile.yaml
+++ b/devfiles/java-springboot/devfile.yaml
@@ -30,6 +30,9 @@ components:
       volumeMounts:
         - name: springbootpvc
           path: /data
+  - volume:
+      name: springbootpvc
+      size: 4Gi
 commands:
   - exec:
       id: devBuild


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysun.j.faisal@ibm.com>

Adding in the volume components, which all devfiles will require once https://github.com/openshift/odo/pull/3584 is merged

This requires any container component having volume mounts to have a corresponding volume component.

Volume component's size is optional. In this case, odo will default to `5Gi` as it was previously.