### PR TITLE
Update workdir for devfiles to use proper sync dir

### DIFF
--- a/devfiles/java-openliberty/devfile.yaml
+++ b/devfiles/java-openliberty/devfile.yaml
@@ -47,7 +47,7 @@ commands:
                                                             && mvn -Dmaven.repo.local=/mvn/repository package
                                                             && touch ./.disable-bld-cmd;
                    fi
-      workingDir: /projects/user-app
+      workingDir: /projects
       attributes:
         restart: "false"
       group:
@@ -57,7 +57,7 @@ commands:
       id: devRun
       component: devruntime 
       commandLine: mvn -Dmaven.repo.local=/mvn/repository -Dliberty.runtime.version=20.0.0.6 -DhotTests=true liberty:dev
-      workingDir: /projects/user-app
+      workingDir: /projects
       attributes:
         restart: "false"
       group:

--- a/devfiles/java-quarkus/devfile.yaml
+++ b/devfiles/java-quarkus/devfile.yaml
@@ -27,7 +27,7 @@ commands:
       id: init-compile
       component: tools
       commandLine: "mvn compile"
-      workingDir: $CHE_PROJECTS_ROOT/quarkus-ex
+      workingDir: $PROJECTS_ROOT
   - exec:
       id: dev-run
       component: tools
@@ -37,7 +37,7 @@ commands:
       group:
         kind: run
         isDefault: true
-      workingDir: $CHE_PROJECTS_ROOT/quarkus-ex
+      workingDir: $PROJECTS_ROOT
       
 events:
   postStart:

--- a/devfiles/java-springboot/devfile.yaml
+++ b/devfiles/java-springboot/devfile.yaml
@@ -38,7 +38,7 @@ commands:
       id: devBuild
       component: tools
       commandLine: "/artifacts/bin/build-container-full.sh"
-      workingDir: /projects/springbootproject
+      workingDir: /projects
       group:
         kind: build
         isDefault: true


### PR DESCRIPTION
### To be merged after https://github.com/openshift/odo/pull/3662 is merged

https://github.com/openshift/odo/pull/3662 updates the logic odo uses to determine the directory to mount and sync the user's source code to.

As such, the command working directory for some devfiles in this registry needed to be updated:
- Change `/projects/<projectName>` to `/projects`
- Change `$CHE_PROJECTS_ROOT` to `$PROJECTS_ROOT`