### PR TITLE
Fix OpenLiberty build command

### DIFF
--- a/devfiles/java-openliberty/devfile.yaml
+++ b/devfiles/java-openliberty/devfile.yaml
@@ -37,7 +37,7 @@ commands:
   - exec:
       id: devBuild
       component: devruntime 
-      commandLine: if [ -e /projects/user-app/.disable-bld-cmd ];
+      commandLine: if [ -e /projects/.disable-bld-cmd ];
                    then
                        echo "found the disable file" && echo "devBuild command will not run" && exit 0;
                    else

--- a/devfiles/java-openliberty/devfile.yaml
+++ b/devfiles/java-openliberty/devfile.yaml
@@ -42,8 +42,8 @@ commands:
                        echo "found the disable file" && echo "devBuild command will not run" && exit 0;
                    else
                        echo "will run the devBuild command" && echo "...moving liberty"
-                                                            && mkdir -p /projects/user-app/target/liberty
-                                                            && mv /opt/ol/wlp /projects/user-app/target/liberty
+                                                            && mkdir -p /projects/target/liberty
+                                                            && mv /opt/ol/wlp /projects/target/liberty
                                                             && mvn -Dmaven.repo.local=/mvn/repository package
                                                             && touch ./.disable-bld-cmd;
                    fi


### PR DESCRIPTION
When https://github.com/odo-devfiles/registry/pull/28 was merged, I missed updating the build command in the open liberty devfile from `/projects/user-app` to `/projects`