### PR TITLE
Add project names to index.json

### DIFF
--- a/devfiles/index.json
+++ b/devfiles/index.json
@@ -21,7 +21,10 @@
     "language": "java",
     "links": {
       "self": "/devfiles/java-openliberty/devfile.yaml"
-    }
+    },
+    "projects": [
+      "user-app"
+    ]
   },
   {
     "name": "java-quarkus",
@@ -35,7 +38,10 @@
     "language": "java",
     "links": {
       "self": "/devfiles/java-quarkus/devfile.yaml"
-    }
+    },
+    "projects": [
+      "quarkus-ex"
+    ]
   },
   {
     "name": "java-springboot",
@@ -51,7 +57,10 @@
     "language": "java",
     "links": {
       "self": "/devfiles/java-springboot/devfile.yaml"
-    }
+    },
+    "projects": [
+      "springbootproject"
+    ]
   },
   {
     "name": "nodejs",
@@ -66,6 +75,9 @@
     "language": "nodejs",
     "links": {
       "self": "/devfiles/nodejs/devfile.yaml"
-    }
+    },
+    "projects": [
+      "nodejs-starter"
+    ]
   }
 ]

--- a/tools/types/devfile.go
+++ b/tools/types/devfile.go
@@ -1,0 +1,69 @@
+package types
+
+// Devfile200 partial Devfile schema.
+// Only contains structs for projects at the moment, as we don't need to parse the entire devfile
+type Devfile200 struct {
+	// Projects worked on in the workspace, containing names and sources locations
+	Projects []Project `json:"projects,omitempty" yaml:"projects,omitempty"`
+}
+
+// Project project defined in devfile
+type Project struct {
+
+	// Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.
+	ClonePath string `json:"clonePath,omitempty" yaml:"clonePath,omitempty"`
+
+	// Project's Git source
+	Git *Git `json:"git,omitempty" yaml:"git,omitempty"`
+
+	// Project's GitHub source
+	Github *Github `json:"github,omitempty" yaml:"github,omitempty"`
+
+	// Project name
+	Name string `json:"name" yaml:"name"`
+
+	// Project's Zip source
+	Zip *Zip `json:"zip,omitempty" yaml:"zip,omitempty"`
+}
+
+// Git Project's Git source
+type Git struct {
+
+	// The branch to check
+	Branch string `json:"branch,omitempty"`
+
+	// Project's source location address. Should be URL for git and github located projects, or; file:// for zip
+	Location string `json:"location,omitempty"`
+
+	// Part of project to populate in the working directory.
+	SparseCheckoutDir string `json:"sparseCheckoutDir,omitempty"`
+
+	// The tag or commit id to reset the checked out branch to
+	StartPoint string `json:"startPoint,omitempty"`
+}
+
+// Github Project's GitHub source
+type Github struct {
+
+	// The branch to check
+	Branch string `json:"branch,omitempty" yaml:"branch,omitempty"`
+
+	// Project's source location address. Should be URL for git and github located projects, or; file:// for zip
+	Location string `json:"location,omitempty" yaml:"location,omitempty"`
+
+	// Part of project to populate in the working directory.
+	SparseCheckoutDir string `json:"sparseCheckoutDir,omitempty" yaml:"sparseCheckoutDir,omitempty"`
+
+	// The tag or commit id to reset the checked out branch to
+	StartPoint string `json:"startPoint,omitempty" yaml:"startPoint,omitempty"`
+}
+
+// Zip Project's Zip source
+type Zip struct {
+
+	// Project's source location address. Should be URL for git and github located projects, or; file:// for zip
+	Location string `json:"location,omitempty" yaml:"location,omitempty"`
+
+	// Part of project to populate in the working directory.
+	SparseCheckoutDir string `json:"sparseCheckoutDir,omitempty" yaml:"sparseCheckoutDir,omitempty"`
+}

--- a/tools/types/meta.go
+++ b/tools/types/meta.go
@@ -13,10 +13,11 @@ type Meta struct {
 }
 
 // MetaIndex is one item in index.json
-// This is Meta extended with Links field
+// This is Meta extended with Links and Projects fields
 type MetaIndex struct {
 	Meta
-	Links Links `yaml:"links,omitempty" json:"links,omitempty"`
+	Links    Links    `yaml:"links,omitempty" json:"links,omitempty"`
+	Projects []string `yaml:"projects,omitempty" json:"projects,omitempty"`
 }
 type Links struct {
 	Self string `yaml:"self,omitempty" json:"self,omitempty"`


### PR DESCRIPTION
This PR updates the registry's index generator tool to add the list of projects in each devfile to the index.json file, when it is being generated. I've also included an updated index.json that includes the projects in each devfile, and it was generated using the updated index generator.

As the devfile parser and types are not yet separated into a separate project (and odo also does not support go modules), I've manually copied a subset of the devfile spec (just the `Project` field)