### PR TITLE
renamed the endpoint from 8080/http to 8080-http to make it adapter friendly

### DIFF
--- a/devfiles/java-quarkus/devfile.yaml
+++ b/devfiles/java-quarkus/devfile.yaml
@@ -18,7 +18,7 @@ components:
         - name: m2
           path: /home/user/.m2
       endpoints:
-        - name: '8080/http'
+        - name: '8080-http'
           targetPort: 8080
   - name: m2
     volume:


### PR DESCRIPTION
Related odo issue https://github.com/openshift/odo/issues/4125

So the `8080/http` would be an invalid when used in a url slug due to the `/`. Now odo is smart enough to change that to `8080-http` but then adapter also has to do that.
So for a quick fix I have renamed `8080/http` to `8080-http`, this is not a solution. Solution could be mostly around failing the url name validation but I also like that odo is smart so while we get to conclusion a quick fix to unblock adapters. 