### PR TITLE
Update node.js default ubi image

### DIFF
--- a/devfiles/nodejs/devfile.yaml
+++ b/devfiles/nodejs/devfile.yaml
@@ -12,7 +12,7 @@ starterProjects:
 components:
   - name: runtime
     container:
-      image: registry.access.redhat.com/ubi8/nodejs-12:1-45
+      image: registry.access.redhat.com/ubi8/nodejs-14:latest
       memoryLimit: 1024Mi
       mountSources: true
       sourceMapping: /project

--- a/devfiles/nodejs/devfile.yaml
+++ b/devfiles/nodejs/devfile.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.0.0
 metadata:
   name: nodejs
-  version: 1.0.0
+  version: 2.0.0
   alpha.build-dockerfile: "https://raw.githubusercontent.com/odo-devfiles/registry/master/devfiles/nodejs/build/Dockerfile"
   alpha.deployment-manifest: "https://raw.githubusercontent.com/odo-devfiles/registry/master/devfiles/nodejs/deploy/deployment-manifest.yaml"
 starterProjects:


### PR DESCRIPTION
Recently the **Red Hat Software Collections** released the node.js-14 UBI image (since this is an LTS version, should be fine to use it as the default image on devfiles).

Since we don't know how you guys bump devfiles versions we left that unchanged (v1.0.0). If I also have to bump the version in this PR please let me know.