### PR TITLE
nodejs catalog entry only works with apps that bind to port 3000

### DIFF
--- a/devfiles/nodejs/devfile.yaml
+++ b/devfiles/nodejs/devfile.yaml
@@ -16,9 +16,6 @@ components:
       memoryLimit: 1024Mi
       mountSources: true
       sourceMapping: /project
-      endpoints:
-        - name: http-3000
-          targetPort: 3000
 commands:
   - id: install
     exec:


### PR DESCRIPTION
Including an optional "Route" that is hard-coded to 3000 is a risky assumption for a catalog example.  

Feel free to close this issue if the default nodejs example is only expected to be used with the --starter repo.

Expected impact of this change:
* No route creation by default.  After this change, catalog users will need to run `odo url create --port 3000` (or similar) as a separate step before connecting to the default nodejs example.  This makes the user-experience one step longer, but it would allow the reference catalog example to be used with applications that do not bind to 3000 by default.
* Users with apps that bind to `8080` can successfully use the default catalog entry for nodejs.  If they would like to expose a route, they can do so by running `odo url create --port 8080`.