### PR TITLE
improves quarkus devfile by setting host and logging manager explicility. logging manager was always recommended, and host became required after 1.7+

### DIFF
--- a/devfiles/java-quarkus/devfile.yaml
+++ b/devfiles/java-quarkus/devfile.yaml
@@ -4,10 +4,12 @@ metadata:
   version: 1.1.0
   website: https://quarkus.io
 starterProjects:
-  - name: quarkus-ex
-    git:
-      remotes:
-        origin: https://github.com/odo-devfiles/quarkus-ex
+  - name: community
+    zip:
+      location: https://code.quarkus.io/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-micrometer&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift&cn=devfile
+  - name: redhat-product
+    zip:
+      location: https://code.quarkus.redhat.com/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift
 components:
   - name: tools
     container:
@@ -32,7 +34,7 @@ commands:
   - id: dev-run
     exec:
       component: tools
-      commandLine: "mvn -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev"
+      commandLine: "mvn -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
       hotReloadCapable: true
       group:
         kind: run
@@ -41,13 +43,12 @@ commands:
   - id: dev-debug
     exec:
       component: tools
-      commandLine: "mvn -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Ddebug=${DEBUG_PORT}"
+      commandLine: "mvn -Dmaven.repo.local=/home/user/.m2/repository quarkus:dev -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Ddebug=${DEBUG_PORT}"
       hotReloadCapable: true
       group:
         kind: debug
         isDefault: true
       workingDir: $PROJECTS_ROOT
-        
 events:
   postStart:
     - init-compile


### PR DESCRIPTION
in addition removed external git starter as it was never going to be updated
fast enough.

instead added a community and product zip download using code.quarkus.io
and code.quarkus.redhat.com respectively. This means devfile will always
pick up the latest default supported version and that get the example
to have openshift, metrics and health default enabled.

we might want to have a kubernates version too - or even leave that extension
out and let it be up to the user to handle.